### PR TITLE
Rejigger the 'repoid-cell' to allow us to munge some strings

### DIFF
--- a/app/components/submissions-repoid-cell.js
+++ b/app/components/submissions-repoid-cell.js
@@ -1,10 +1,50 @@
 import Component from '@ember/component';
 
 export default Component.extend({
+  store: Ember.inject.service(),
+  repoCopies: null,
+  jscholarshipCheckString: '/handle/',
+
+  init() {
+    this._super(...arguments);
+
+    const publicationId = this.get('record.publication.id');
+    this.get('store').query('repositoryCopy', {
+      query: {
+        term: { publication: publicationId }
+      },
+      from: 0,
+      size: 100
+    }).then(rc => this.set('repoCopies', rc));
+  },
   didReceiveAttrs() {
     this._super(...arguments);
     if ($('#manuscriptIdTooltip').length == 0) {
       ($('.table-header:nth-child(6)')).append('<span id="manuscriptIdTooltip" tooltip-position="bottom" tooltip="ID are assigned to manuscript by target repositories."><i class="fas fa-info-circle d-inline"></i></span>');
     }
-  }
+  },
+
+  displayIds: Ember.computed('repoCopies', function () {
+    const rc = this.get('repoCopies');
+    if (!rc) {
+      return [];
+    }
+
+    return rc.filter(repoCopy => !!repoCopy.get('externalIds')).map((repoCopy) => {
+      const check = this.get('jscholarshipCheckString');
+
+      // If an ID has the 'check' string, only display the sub-string after the 'check' string
+      let ids = repoCopy.get('externalIds').map((id) => { // eslint-disable-line
+        return {
+          title: id,
+          display: id.includes(check) ? id.slice(id.indexOf(check) + check.length) : id
+        };
+      });
+      return {
+        url: repoCopy.get('accessUrl'),
+        ids
+      };
+      // Note the 'ids' notation in the above object gets translated to: ids: ids
+    });
+  })
 });

--- a/app/components/submissions-repoid-cell.js
+++ b/app/components/submissions-repoid-cell.js
@@ -24,6 +24,20 @@ export default Component.extend({
     }
   },
 
+  /**
+   * Formatted:
+   *  [
+   *    {
+   *      url: '',
+   *      ids: [
+   *        {
+   *          title: 'href-worthy-id',
+   *          display: 'somewhat-more-human-readable'
+   *        }
+   *      ]
+   *    }
+   *  ]
+   */
   displayIds: Ember.computed('repoCopies', function () {
     const rc = this.get('repoCopies');
     if (!rc) {

--- a/app/templates/components/submissions-repoid-cell.hbs
+++ b/app/templates/components/submissions-repoid-cell.hbs
@@ -1,26 +1,20 @@
 <div style="min-width:150px">
-{{#each (search-associated 'repositoryCopy' 'publication' (get record 'publication.id')) as |repositoryCopy index|}}
-  {{#if repositoryCopy.externalIds}}
+  {{#each displayIds as |idInfo index|}}
     {{if index ', '}}
-    {{#if repositoryCopy.accessUrl}}
-    <ul class="repoid-cell">
-      {{#each repositoryCopy.externalIds as |externalIds|}}
-        <a href="{{repositoryCopy.accessUrl}}" target="_blank">
-          <li title="{{externalIds}}">{{externalIds}}</li>
-        </a>
-      {{/each}}
-    </ul>
-    {{else}}
+    {{#if idInfo.url}}
       <ul class="repoid-cell">
-        {{#each repositoryCopy.externalIds as |externalIds|}}
-          <li title="{{externalIds}}">{{externalIds}}</li>
+        {{#each idInfo.ids as |id|}}
+          <a href="{{url}}" target="_blank">
+            <li title="{{id.title}}">{{id.display}}</li>
+          </a>
         {{/each}}
       </ul>
+    {{else}}
+      {{#each idInfo.ids as |id|}}
+        <li title="{{id.title}}">{{id.display}}</li>
+      {{/each}}
     {{/if}}
   {{else}}
     <span class="nodata-placeholder">Not available</span>
-  {{/if}}
-{{else}}
-  <span class="nodata-placeholder">Not available</span>
-{{/each}}
+  {{/each}}
 </div>

--- a/app/templates/components/submissions-repoid-cell.hbs
+++ b/app/templates/components/submissions-repoid-cell.hbs
@@ -1,20 +1,18 @@
-<div style="min-width:150px">
-  {{#each displayIds as |idInfo index|}}
-    {{if index ', '}}
+{{#each displayIds as |idInfo index|}}
+  <ul class="repoid-cell">
     {{#if idInfo.url}}
-      <ul class="repoid-cell">
-        {{#each idInfo.ids as |id|}}
-          <a href="{{url}}" target="_blank">
-            <li title="{{id.title}}">{{id.display}}</li>
-          </a>
-        {{/each}}
+      {{#each idInfo.ids as |id|}}
+        <a href="{{idInfo.url}}" target="_blank">
+          <li title="{{id.title}}">{{id.display}}</li>
+        </a>
+      {{/each}}
       </ul>
     {{else}}
       {{#each idInfo.ids as |id|}}
         <li title="{{id.title}}">{{id.display}}</li>
       {{/each}}
-    {{/if}}
-  {{else}}
-    <span class="nodata-placeholder">Not available</span>
-  {{/each}}
-</div>
+    </ul>
+  {{/if}}
+{{else}}
+  <span class="nodata-placeholder">Not available</span>
+{{/each}}


### PR DESCRIPTION
* Simplified the `repoid-cell` template to extract some logic
* `repoid-cell.js`
  * Put extracted logic into the component JS file
  * Rips apart `repositoryCopy` objects to something that can be used in the templates more directly, while adding the ability to manipulate various values. `displayIds` is used in the template.

Note for string manipulation, see around line 40 in the JS